### PR TITLE
Product Index modificat butoanele de schimbat paginile

### DIFF
--- a/OnlineShop/Controllers/ProductsController.cs
+++ b/OnlineShop/Controllers/ProductsController.cs
@@ -101,7 +101,9 @@ namespace OnlineShop.Controllers
 
             // numarul ultimei pagini
             ViewBag.lastPage = Math.Ceiling((float)totalItems / (float)perPage);
-
+            
+            ViewBag.CurrentPage = currentPage == 0 ? 1 : currentPage;
+            
             // trimitem produsele catre view
             ViewBag.Products = paginatedProducts;
 

--- a/OnlineShop/Views/Products/Index.cshtml
+++ b/OnlineShop/Views/Products/Index.cshtml
@@ -73,27 +73,28 @@
 }
 
 
-@* Afisare paginata a produselor *@
+@* butoane de navigare intre pagini *@
 
 <div>
-
     <nav aria-label="Page navigation example">
         <ul class="pagination">
-            <li class="page-item">
-                <a class="page-link" href="@ViewBag.PaginationBaseUrl=1" aria-label="Previous">
+            <li class="page-item @(ViewBag.CurrentPage == 1 ? "disabled" : "")">
+                <a class="page-link" href="@ViewBag.PaginationBaseUrl=@(ViewBag.CurrentPage - 1)" aria-label="Previous">
                     <span aria-hidden="true">&laquo;</span>
                 </a>
             </li>
             @for (int i = 1; i <= ViewBag.lastPage; i++)
             {
-                <li class="page-item"> <a class="page-link" href="@ViewBag.PaginationBaseUrl=@i">@(i)</a> </li>
+                <li class="page-item @(i == ViewBag.CurrentPage ? "active" : "")">
+                    <a class="page-link" href="@ViewBag.PaginationBaseUrl=@i">@(i)</a>
+                </li>
             }
-            <li class="page-item">
-                <a class="page-link" href="@ViewBag.PaginationBaseUrl=@(ViewBag.lastPage)" aria-label="Next">
+            <li class="page-item @(ViewBag.CurrentPage == ViewBag.lastPage ? "disabled" : "")">
+                <a class="page-link" href="@ViewBag.PaginationBaseUrl=@(ViewBag.CurrentPage + 1)" aria-label="Next">
                     <span aria-hidden="true">&raquo;</span>
                 </a>
             </li>
         </ul>
     </nav>
-
 </div>
+


### PR DESCRIPTION
This pull request includes changes to the pagination logic in the `ProductsController` and the corresponding view in `Index.cshtml` to improve navigation between pages.

### Pagination Improvements:

* [`OnlineShop/Controllers/ProductsController.cs`](diffhunk://#diff-ffcf9c00eba653951eade2a3faaf6df3b732906e524856e4b6ee8c14bf7bfc3aR105-R106): Added `ViewBag.CurrentPage` to ensure the current page is set correctly, defaulting to 1 if `currentPage` is 0.

* [`OnlineShop/Views/Products/Index.cshtml`](diffhunk://#diff-9d8db828e4d407ba2ae2a5183e8847c52a451e70e3e0b097c377f1c848eb7b44L76-R100): Updated the pagination buttons to reflect the current page state, disabling the "Previous" button on the first page and the "Next" button on the last page. The current page button is now highlighted.